### PR TITLE
Prepare for release v1.4.0 (screen lock)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.serwylo.babydots"
         minSdkVersion 22
         targetSdkVersion 30
-        versionCode 10300
-        versionName "1.3.0"
+        versionCode 10400
+        versionName "1.4.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/fastlane/metadata/android/en-US/changelogs/10400.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10400.txt
@@ -1,0 +1,3 @@
+Add optional screen locking, preventing accidental touches from excited babies.
+
+Please provide any feedback or report any issues on the issue tracker at https://github.com/babydots/babydots/issues.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Sooth and calm young babies
+Soothe and calm young babies


### PR DESCRIPTION
Bump version number and fix a typo in the English short description (Soothe instead of Sooth)