### PR TITLE
Bump for release v1.4.1.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.serwylo.babydots"
         minSdkVersion 22
         targetSdkVersion 30
-        versionCode 10400
-        versionName "1.4.0"
+        versionCode 10401
+        versionName "1.4.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/fastlane/metadata/android/de/changelogs/10401.txt
+++ b/fastlane/metadata/android/de/changelogs/10401.txt
@@ -1,0 +1,6 @@
+Eine optionale Bildschirmsperre hinzugefügt, um versehentliche Berührungen durch aufgeregte Babys zu verhindern.
+
+Übersetzungen:
+* Niederländisch hinzugefügt (danke vistaus)
+
+Bitte geben Sie Rückmeldung oder melden Sie Probleme unter https://github.com/babydots/babydots/issues.

--- a/fastlane/metadata/android/en-US/changelogs/10401.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10401.txt
@@ -1,0 +1,9 @@
+Add optional screen locking, preventing accidental touches from excited babies.
+
+Improved display of messages when tapping unlock button many times fast.
+
+Translations:
+* Added Dutch (thanks vistaus)
+* Updated translations
+
+Please provide any feedback or report any issues on the issue tracker at https://github.com/babydots/babydots/issues.

--- a/fastlane/metadata/android/it/changelogs/10401.txt
+++ b/fastlane/metadata/android/it/changelogs/10401.txt
@@ -1,0 +1,6 @@
+Aggiunge il blocco opzionale dello schermo, per prevenire i tocchi accidentali da parte dei bambini eccitati.
+
+Traduzioni:
+* olandese aggiunto (grazie vistaus)
+
+Fornisci qualsiasi commenti o segnala eventuali problemi su https://github.com/babydots/babydots/issues.

--- a/fastlane/metadata/android/nb-NO/changelogs/10401.txt
+++ b/fastlane/metadata/android/nb-NO/changelogs/10401.txt
@@ -1,0 +1,6 @@
+Valgfri skjermlåsing lagt til, noe som forhindrer utiltenkte trykk fra babyfingre.
+
+Oversettelser:
+* Hollandsk (takk til vistaus)
+
+Gi tilbakemeldinger om problemer, eller i feilsporeren på https://github.com/babydots/babydots/issues.

--- a/fastlane/metadata/android/tr/changelogs/10401.txt
+++ b/fastlane/metadata/android/tr/changelogs/10401.txt
@@ -1,0 +1,6 @@
+Heyecanlı bebeklerin yanlışlıkla dokunmasını önleyen isteğe bağlı ekran kilidi eklendi.
+
+Çeviriler:
+* Flemenkçe eklendi (teşekkürler vistaus)
+
+Lütfen https://github.com/babydots/babydots/issues adresinde geri bildirim sağlayın veya sorun bildirin.


### PR DESCRIPTION
Not sure what weblate will do if I copy an initial changelog based on the v1.4.0 release.
Will this come up as 'No translation requried'? Or will it say 'Incorrect translation' or something?
Hopefully this doesn't cause more issues than it tries to solve. The idea is to give translators
a bunch of context so they don't need to re-translate the changelog from a previous release.