### PR TITLE
Fixed OOM caused by graphics memory leak.

### DIFF
--- a/app/src/main/java/com/serwylo/babydots/AnimatedDots.kt
+++ b/app/src/main/java/com/serwylo/babydots/AnimatedDots.kt
@@ -122,9 +122,9 @@ class AnimatedDots @JvmOverloads constructor(
     private val drawPaths = false
 
     init {
-
-        dotStrokePaint.style = Paint.Style.STROKE
-        dotStrokePaint.strokeWidth = 8f
+        // see comment at onDraw()
+        //dotStrokePaint.style = Paint.Style.STROKE
+        //dotStrokePaint.strokeWidth = 8f
 
         linePaint.style = Paint.Style.STROKE
         linePaint.color = Color.BLACK
@@ -191,6 +191,14 @@ class AnimatedDots @JvmOverloads constructor(
 
     private var lastTimeStep: Long = System.currentTimeMillis()
 
+    /**
+     * Drawing dot borders with Paint.style.STROKE causes graphics memory leak on some devices.
+     * Because of that, drawing the borders is currently substituted by drawing a larger circle below/before
+     * the actual filler circle.
+     * This is not an optimal solution but it does not use that much extra resources in this case.
+     * See:
+     *  - Bug report: https://github.com/babydots/babydots/issues/49
+     */
     override fun onDraw(canvas: Canvas?) {
         super.onDraw(canvas)
 
@@ -238,8 +246,9 @@ class AnimatedDots @JvmOverloads constructor(
 
             if (x > -radius && x < width + radius && y > -radius && y < height + radius) {
                 val newSize = radius + (radius * dot.zoomAnimation)
+                //draw slightly larger circle first to simulate dot border
+                canvas?.drawCircle(x, y, newSize + 8f, dotStrokePaint)
                 canvas?.drawCircle(x, y, newSize, dotFillPaint)
-                canvas?.drawCircle(x, y, newSize, dotStrokePaint)
             }
         }
     }


### PR DESCRIPTION
Fixes #49 

Now instead of drawing borders to dots we draw larger filled dot below the which acts as an border. 

This isn't a perfect solution but it fixed it on my phone and visually looked the same as before. Memory consumption remained stable and the application didn't crash anymore.